### PR TITLE
feat(vuex): add store and module

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
 NODE_ENV=development
 PUBLIC_PATH=http://localhost:3001/
+
+REMOTE_ROOT=root@http://localhost:3000/remoteEntry.js

--- a/.env.other
+++ b/.env.other
@@ -1,2 +1,4 @@
 NODE_ENV=production
 PUBLIC_PATH=http://localhost:3001/
+
+REMOTE_ROOT=root@http://localhost:3000/remoteEntry.js

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,4 @@
 NODE_ENV=production
 PUBLIC_PATH=https://mfe-module-federation-vue-cart.netlify.app
+
+REMOTE_ROOT=root@https://mfe-module-federation-vue-root.netlify.app/remoteEntry.js

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "core-js": "^3.6.5",
     "vue": "^2.6.11",
     "vuetify": "^2.4.0",
-    "http-server": "^0.12.3"
+    "http-server": "^0.12.3",
+    "vuex": "^3.6.2"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "5.0.0-beta.2",
@@ -28,7 +29,6 @@
     "vue-template-compiler": "^2.6.11",
     "vuetify-loader": "^1.7.0",
     "webpack": "^5.35.1"
-
   },
   "eslintConfig": {
     "root": true,

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,10 +1,12 @@
 import Vue from 'vue'
 import App from './App.vue'
 import vuetify from './plugins/vuetify'
+import store from './store'
 
 Vue.config.productionTip = false
 
 new Vue({
   vuetify,
+  store,
   render: h => h(App)
 }).$mount('#app')

--- a/src/components/Cart.vue
+++ b/src/components/Cart.vue
@@ -15,6 +15,9 @@
       <v-divider></v-divider>
       <v-stepper-step :complete="step == 4" step="4"> Finished </v-stepper-step>
     </v-stepper-header>
+    <v-btn text @click="$store.dispatch('user/setUser', { usuario: 'Tássio' })">
+      change name
+    </v-btn>
 
     <v-stepper-items>
       <v-stepper-content step="1">
@@ -52,9 +55,15 @@ import CartProductList from "./CartProductList.vue";
 import CartPayment from "./CartPayment.vue";
 import CartAddress from "./CartAddress.vue";
 import CartFinish from "./CartFinish.vue";
+
 export default {
   name: "Cart",
-  components: { CartProductList, CartPayment, CartAddress, CartFinish },
+  components: {
+    CartProductList,
+    CartPayment,
+    CartAddress,
+    CartFinish,
+  },
   data() {
     return {
       step: 1,

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,11 @@
+import Vue from "vue";
+
+import Vuex from "vuex";
+
+import userModuleFromRoot from 'root/userModuleFromRoot'
+
+Vue.use(Vuex);
+
+const store = new Vuex.Store({ modules: { user: userModuleFromRoot } });
+
+export default store;

--- a/vue.config.js
+++ b/vue.config.js
@@ -12,6 +12,9 @@ module.exports = {
         exposes: {
           "./Cart": "./src/components/Cart",
         },
+        remotes: {
+          root: process.env.REMOTE_ROOT,
+        },
         shared: require("./package.json").dependencies,
       }),
     ],


### PR DESCRIPTION
I've created a separate module to expose it and use the namespace approach as @schirrel thought. 

The idea here is to use the global module shared from the root/host/shelf.

Other PRs (into other MFEs:
https://github.com/mfe-module-federation-vue/root/pull/1
https://github.com/mfe-module-federation-vue/profile/pull/1